### PR TITLE
Update Package for Swift 4

### DIFF
--- a/Sources/PlayingCard/PlayingCard.swift
+++ b/Sources/PlayingCard/PlayingCard.swift
@@ -9,8 +9,8 @@
 */
 
 public struct PlayingCard {
-    let rank: Rank
-    let suit: Suit
+    public let rank: Rank
+    public let suit: Suit
 
     public init(rank: Rank, suit: Suit) {
         self.rank = rank

--- a/Sources/PlayingCard/PlayingCard.swift
+++ b/Sources/PlayingCard/PlayingCard.swift
@@ -28,7 +28,7 @@ extension PlayingCard: Comparable {
 
 // MARK: - CustomStringConvertible
 
-extension PlayingCard : CustomStringConvertible {
+extension PlayingCard: CustomStringConvertible {
     public var description: String {
         return "\(suit) \(rank)"
     }

--- a/Sources/PlayingCard/PlayingCard.swift
+++ b/Sources/PlayingCard/PlayingCard.swift
@@ -8,21 +8,13 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-public struct PlayingCard {
+public struct PlayingCard: Equatable {
     public let rank: Rank
     public let suit: Suit
 
     public init(rank: Rank, suit: Suit) {
         self.rank = rank
         self.suit = suit
-    }
-}
-
-// MARK: - Equatable
-
-extension PlayingCard: Equatable {
-    public static func ==(lhs: PlayingCard, rhs: PlayingCard) -> Bool {
-      return lhs.rank == rhs.rank && lhs.suit == rhs.suit
     }
 }
 

--- a/Sources/PlayingCard/PlayingCard.swift
+++ b/Sources/PlayingCard/PlayingCard.swift
@@ -8,7 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-public struct PlayingCard: Equatable {
+public struct PlayingCard: Equatable, Hashable {
     public let rank: Rank
     public let suit: Suit
 

--- a/Sources/PlayingCard/Rank.swift
+++ b/Sources/PlayingCard/Rank.swift
@@ -8,7 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-public enum Rank : Int {
+public enum Rank: Int {
     case two = 2
     case three, four, five, six, seven, eight, nine, ten
     case jack, queen, king, ace
@@ -16,7 +16,7 @@ public enum Rank : Int {
 
 // MARK: - Comparable
 
-extension Rank : Comparable {
+extension Rank: Comparable {
     public static func <(lhs: Rank, rhs: Rank) -> Bool {
         switch (lhs, rhs) {
         case (_, _) where lhs == rhs:
@@ -31,7 +31,7 @@ extension Rank : Comparable {
 
 // MARK: - CustomStringConvertible
 
-extension Rank : CustomStringConvertible {
+extension Rank: CustomStringConvertible {
     public var description: String {
         switch self {
         case .ace: return "A"

--- a/Sources/PlayingCard/Rank.swift
+++ b/Sources/PlayingCard/Rank.swift
@@ -8,7 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-public enum Rank: Int {
+public enum Rank: Int, CaseIterable {
     case two = 2
     case three, four, five, six, seven, eight, nine, ten
     case jack, queen, king, ace

--- a/Sources/PlayingCard/Suit.swift
+++ b/Sources/PlayingCard/Suit.swift
@@ -8,7 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-public enum Suit: String {
+public enum Suit: String, CaseIterable {
     case spades, hearts, diamonds, clubs
 }
 

--- a/Sources/PlayingCard/Suit.swift
+++ b/Sources/PlayingCard/Suit.swift
@@ -31,7 +31,7 @@ extension Suit: Comparable {
 
 // MARK: - CustomStringConvertible
 
-extension Suit : CustomStringConvertible {
+extension Suit: CustomStringConvertible {
     public var description: String {
         switch self {
         case .spades: return "♠︎"


### PR DESCRIPTION
This PR makes several updates that take advantage of new language features in Swift 4, including conformance to `CaseIterable` and automatic synthesis of `Equatable` and `Hashable` conformance. It also changes the `rank` and `suit` properties of `PlayingCard` to have `public` access, which should have been the case from the start.